### PR TITLE
Update 월급두배받는법.md

### DIFF
--- a/teams/월급두배받는법.md
+++ b/teams/월급두배받는법.md
@@ -60,9 +60,9 @@ SNS에 HackaLearn 이벤트 참여중임을 알 수 있는 포스트를 #hackale
 
 | GitHub ID                                          | 포스트 링크         |
 | -------------------------------------------------- | ------------------- |
-| [@seoljiwon](https://github.com/seoljiwon)         | _링크를 남겨주세요_ |
+| [@seoljiwon](https://github.com/seoljiwon)         | [블로그 링크](https://c0dingst0ry.tistory.com/2) |
 | [@subeenpark-io](https://github.com/subeenpark-io) | _링크를 남겨주세요_ |
 | [@HoYoungChun](https://github.com/HoYoungChun)     | [블로그 링크](https://supremo7.tistory.com/275) |
-| [@ksiyeon27](https://github.com/ksiyeon27)         | [블로그 링크](https://c0dingst0ry.tistory.com/2) |
+| [@ksiyeon27](https://github.com/ksiyeon27)         | _링크를 남겨주세요_ |
 
 


### PR DESCRIPTION
지난번에 블로그 링크가 다른 팀원의 아이디에 잘못 들어가 본인 @seoljiwon 아이디 옆으로 수정합니다. 시스템 반영 및 merge 가능할까요?

> 각 **챌린지 미션**을 완료 할때 마다 **각자 자신의 항목을 수정하는** PR을 생성해 주세요.

## 챌린저 정보 ##

챌린저의 정보를 아래에 남겨주세요.

* 팀 이름: 월급두배받는법

> Microsoft Learn 프로필 URL은 `https://docs.microsoft.com/ko-kr/users/******`와 같이 생겼습니다.

* Microsoft Learn 프로필 URL: https://docs.microsoft.com/ko-kr/users/90712025/
* GitHub ID: @seoljiwon 


아래는 SNS 챌린지의 경우에만 입력해 주세요.

> 다양한 SNS가 있지만, 여기서는 트위터, 페이스북, 인스타그램만 인정합니다.

* SNS 이름:
* SNS ID:


## 완료된 챌린지 ##

> 이번에 완료된 챌린지의 내용을 마킹해주세요.

* [ ] 애저 정적 웹 앱 챌린지 완료
* [ ] 깃헙 액션 챌린지 완료
* [ ] 소셜미디어 인증샷 챌린지 완료
* [ ] 애저 정적 웹 앱 URL 제출 챌린지 완료
* [ ] 애저 정적 웹 앱 리포지토리 제출 챌린지 완료
* [X] 블로그 후기 URL 제출 챌린지 완료
